### PR TITLE
Fix installing Google Cloud CLI in GitHub deployment workflow

### DIFF
--- a/.github/workflows/firebase-hosting-dev.yml
+++ b/.github/workflows/firebase-hosting-dev.yml
@@ -22,7 +22,7 @@ jobs:
 
       - name: Install Google Cloud SDK components
         run: |
-          gcloud components install beta
+          sudo apt-get install google-cloud-cli
 
       - name: Configure Google Cloud Project
         run: |


### PR DESCRIPTION
Should fix this error:

ERROR: (gcloud.components.install)
You cannot perform this action because the Google Cloud CLI component manager is disabled for this installation. You can run the following command to achieve the same result for this installation:
sudo apt-get install google-cloud-cli