### PR TITLE
Fix importing flights to capzlog as PIC (PICName is required)

### DIFF
--- a/internal/capzlog/import.go
+++ b/internal/capzlog/import.go
@@ -61,8 +61,9 @@ func capzlogMapFlight(id, registration string, pf vuela.PilotFunction, fr *vuela
 		if fr.Instructor.Id != "" {
 			pname = &fr.Instructor.LastName
 			pfunc = models.PilotFunctionsDual
+		} else { // PIC+SELF (pilot name still required by the Capzlog API in this case)
+			pname = &fr.Pilot.LastName
 		}
-		// else PIC+SELF
 	} else if pf == vuela.PilotFunctionInstructor {
 		pfunc = models.PilotFunctionsInstructorOnPilotSeat
 		withStudent := models.NewMarkerType(models.MarkerTypeWithStudent)


### PR DESCRIPTION
The displayed PIC name in capzlog is "Self" if the pilot function is "PIC", but nevertheless the PIC name has to be included in the request. Otherwise, the capzlog API returns a 400 Bad Request response with the error message "The PICName field is required.".