### PR TITLE
Shorten deployment workflow names

### DIFF
--- a/.github/workflows/firebase-hosting-dev.yml
+++ b/.github/workflows/firebase-hosting-dev.yml
@@ -1,4 +1,4 @@
-name: Deploy to Firebase Functions on merge (dev)
+name: Deploy (dev)
 'on':
   push:
     branches:

--- a/.github/workflows/firebase-hosting-prod.yml
+++ b/.github/workflows/firebase-hosting-prod.yml
@@ -1,4 +1,4 @@
-name: Deploy to Firebase Functions on release (prod)
+name: Deploy (prod)
 'on':
   push:
     tags:


### PR DESCRIPTION
## Summary
Shorten the deployment workflow names so they fit in the GitHub web UI sidebar.

- `Deploy to Firebase Functions on merge (dev)` → `Deploy (dev)`
- `Deploy to Firebase Functions on release (prod)` → `Deploy (prod)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)