### PR TITLE
Add a "mock" logbook provider for testing in dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,101 @@
+# vuela-pilot-logbook-sync
+
+Google Cloud Functions (Go, 2nd gen) that sync Vuela flights and connections to
+external pilot-logbook systems.
+
+## Functions
+
+| Function | Trigger | Purpose |
+|---|---|---|
+| `activatePilotLogBookSync` | Firestore write on `users/{user}` | When a user's `pilotLogbookSync.status` becomes `new`, activate (connect) their account against the chosen system. |
+| `syncPilotLogBook` | Firestore write on `pilotLogbookSync/{sync}` | When a sync job's `status` is `new`, import the referenced flight into the user's logbook system. |
+| `SyncPilotLookbookWebhook` | HTTP | Re-queues stale sync jobs (`internal.RetryJobs`). |
+
+## Providers
+
+Each external system is a provider package under `internal/`, selected by a
+`type` string (see `internal/const.go`). Dispatch happens via the `switch`
+statements in `internal/activate.go` (activation) and `internal/import.go`
+(import).
+
+| `type` | Package | Notes |
+|---|---|---|
+| `capzlog` | `internal/capzlog` | capzlog.aero (host via `CAPZLOG_HOST`) |
+| `mycontrol` | `internal/mycontrol` | myControl |
+| `mock` | `internal/mock` | No external system — for testing in dev (see below) |
+
+## Testing with the mock provider
+
+`mock` talks to no external system. It logs what it *would* send and returns a
+deterministic outcome **chosen by the apiKey value**, so you can exercise the
+full Firestore-trigger → activation/import → status state-machine in dev by just
+writing Firestore documents.
+
+### apiKey → outcome
+
+Matched case-insensitively; anything not listed succeeds, so the happy path
+"just works".
+
+| apiKey contains | Activation | Import | Resulting status |
+|---|---|---|---|
+| _(default, e.g. `mock`)_ | success | success | activation `success`, flight `success` |
+| `fail-activate` | error | — | user `failure` |
+| `fail-import` | success | generic error | flight `failure` |
+| `fail-auth` | success | auth error | flight `auth_failure`, user `account_failure` |
+
+> Import-failure keys still activate successfully, because a flight is only
+> imported once the user connection is `success`.
+
+### Steps (against `odch-aircraft-logbook-dev`)
+
+1. **Activate a connection.** On a user document (`users/{userId}`), set:
+   ```jsonc
+   "pilotLogbookSync": { "type": "mock", "apiKey": "mock", "status": "new" }
+   ```
+   `activatePilotLogBookSync` runs and flips `pilotLogbookSync.status` to
+   `success` (logs show `[mock] ActivateUser`).
+
+2. **Sync a flight.** Easiest path: with the connection from step 1 active,
+   create/sync a flight for that user in the Vuela dev app — the app writes the
+   `pilotLogbookSync` job document for you, and `syncPilotLogBook` picks it up.
+
+   To trigger it by hand instead, create a document in the `pilotLogbookSync`
+   collection:
+   ```jsonc
+   {
+     "type": "mock",
+     "status": "new",
+     "user":   "<reference to users/{userId}>",
+     "flight": "<reference to an existing flight document>"
+   }
+   ```
+   Notes that will otherwise silently stall the job:
+   - `user` and `flight` must be Firestore **reference** fields (not string
+     paths) — `loadSync` decodes them into `DocumentRef`s.
+   - `flight` must point at a **real Vuela flight nested under an aircraft**
+     (`…/{aircraft}/flights/{flight}`); `loadFlight` reads the aircraft
+     registration via the flight's grandparent. A top-level flight ref fails
+     before any status is written, leaving the job at `new`.
+
+   `syncPilotLogBook` runs, logs `[mock] Import flight …`, and sets the job's
+   `status` to `success`.
+
+3. **Test failure branches.** Repeat step 1 with apiKey `mock-fail-activate`, or
+   step 2 with `mock-fail-import` / `mock-fail-auth`, and confirm the resulting
+   statuses match the table above.
+
+### Reading logs
+
+```sh
+gcloud functions logs read syncPilotLogBook \
+  --gen2 --region=europe-west1 --project=odch-aircraft-logbook-dev --limit=20
+gcloud functions logs read activatePilotLogBookSync \
+  --gen2 --region=europe-west1 --project=odch-aircraft-logbook-dev --limit=20
+```
+
+## Deployment
+
+Deploys run via GitHub Actions: push to `main` deploys **dev**
+(`.github/workflows/firebase-hosting-dev.yml`); pushing a `v*` tag deploys
+**prod** (`firebase-hosting-prod.yml`). For manual deploys use `deploy-dev.sh` /
+`deploy-prod.sh`.

--- a/internal/activate.go
+++ b/internal/activate.go
@@ -7,6 +7,7 @@ import (
 
 	"cloud.google.com/go/firestore"
 	"github.com/odch/aircraft-logbook/functions-go/flightsync/internal/capzlog"
+	"github.com/odch/aircraft-logbook/functions-go/flightsync/internal/mock"
 	"github.com/odch/aircraft-logbook/functions-go/flightsync/internal/mycontrol"
 )
 
@@ -31,6 +32,8 @@ func EnableSync(ctx context.Context, client *firestore.Client, userId, system, a
 		status, description, err = capzlog.ActivateUser(apiKey, systemInstanceIdentifier)
 	case systemMycontrol:
 		status, description, err = mycontrol.ActivateUser(apiKey)
+	case systemMock:
+		status, description, err = mock.ActivateUser(apiKey)
 
 	default:
 		err = fmt.Errorf("system %s not yet supported", system)

--- a/internal/const.go
+++ b/internal/const.go
@@ -2,3 +2,4 @@ package internal
 
 const systemCapzlog = "capzlog"
 const systemMycontrol = "mycontrol"
+const systemMock = "mock"

--- a/internal/import.go
+++ b/internal/import.go
@@ -9,6 +9,7 @@ import (
 	"cloud.google.com/go/firestore"
 	"github.com/mitchellh/mapstructure"
 	"github.com/odch/aircraft-logbook/functions-go/flightsync/internal/capzlog"
+	"github.com/odch/aircraft-logbook/functions-go/flightsync/internal/mock"
 	"github.com/odch/aircraft-logbook/functions-go/flightsync/internal/mycontrol"
 	"github.com/odch/aircraft-logbook/functions-go/flightsync/internal/vuela"
 )
@@ -117,6 +118,8 @@ func syncUser(ctx context.Context, client *firestore.Client, ref *firestore.Docu
 		err = capzlog.Import(user.PilotLogbookSync.ApiKey, systemInstanceIdentifier, id, registration, pf, f)
 	case systemMycontrol:
 		err = mycontrol.Import(user.PilotLogbookSync.ApiKey, id, registration, pf, f)
+	case systemMock:
+		err = mock.Import(user.PilotLogbookSync.ApiKey, id, registration, pf, f)
 	default:
 		err = fmt.Errorf("invalid sync system: %v", sync.Type)
 	}

--- a/internal/mock/mock.go
+++ b/internal/mock/mock.go
@@ -1,0 +1,46 @@
+// Package mock is a logbook provider that talks to no external system. It logs
+// what it "would" send and returns a deterministic outcome chosen by the apiKey
+// value, so the sync/activation functions can be exercised end-to-end in dev.
+//
+// The apiKey selects the outcome (matched case-insensitively):
+//
+//	(default, e.g. "mock")  activate -> success, import -> success
+//	contains "fail-activate" activate -> error          (user status "failure")
+//	contains "fail-import"   import   -> generic error  (flight status "failure")
+//	contains "fail-auth"     import   -> auth error      (flight "auth_failure", user "account_failure")
+//
+// Import-failure outcomes still activate successfully, because a flight is only
+// imported once the user connection is "success".
+package mock
+
+import (
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/odch/aircraft-logbook/functions-go/flightsync/internal/vuela"
+)
+
+func ActivateUser(apiKey string) (status, description string, err error) {
+	log.Printf("[mock] ActivateUser apiKey=%q", apiKey)
+	if strings.Contains(strings.ToLower(apiKey), "fail-activate") {
+		return "", "", fmt.Errorf("mock: simulated activation failure")
+	}
+	return "success", "", nil
+}
+
+func Import(authToken, id, registration string, pf vuela.PilotFunction, f *vuela.FlightLogRecord) error {
+	log.Printf("[mock] Import flight id=%s registration=%s pilotFunction=%d apiKey=%q", id, registration, pf, authToken)
+	log.Printf("[mock] flight record: %+v", f)
+	key := strings.ToLower(authToken)
+	switch {
+	case strings.Contains(key, "fail-auth"):
+		// Message must contain a token the dispatcher recognises so it maps to
+		// flight "auth_failure" + user "account_failure" (see internal/import.go).
+		return fmt.Errorf("mock: simulated MissingRequiredSubscription")
+	case strings.Contains(key, "fail-import"):
+		return fmt.Errorf("mock: simulated import failure")
+	default:
+		return nil
+	}
+}

--- a/internal/mock/mock_test.go
+++ b/internal/mock/mock_test.go
@@ -1,0 +1,31 @@
+package mock
+
+import (
+	"testing"
+
+	"github.com/odch/aircraft-logbook/functions-go/flightsync/internal/vuela"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestActivateUser(t *testing.T) {
+	status, _, err := ActivateUser("mock")
+	assert.Nil(t, err)
+	assert.Equal(t, "success", status)
+
+	_, _, err = ActivateUser("mock-fail-activate")
+	assert.NotNil(t, err)
+}
+
+func TestImport(t *testing.T) {
+	f := &vuela.FlightLogRecord{}
+
+	// default -> success
+	assert.Nil(t, Import("mock", "id", "HBXYZ", vuela.PilotFunctionPilot, f))
+
+	// generic import failure
+	assert.Error(t, Import("mock-fail-import", "id", "HBXYZ", vuela.PilotFunctionPilot, f))
+
+	// auth failure must carry the token the dispatcher keys on
+	err := Import("mock-fail-auth", "id", "HBXYZ", vuela.PilotFunctionPilot, f)
+	assert.ErrorContains(t, err, "MissingRequiredSubscription")
+}


### PR DESCRIPTION
## Why

Testing the sync/activation functions end-to-end needs a real downstream account. Dev points at capzlog's test host, but that's still an external dependency with non-deterministic results, and the **failure** status branches (`auth_failure`, `account_failure`, `failure`) are hard to reproduce on demand.

This adds a third provider, **`mock`**, that talks to no external system — it logs what it *would* send and returns a deterministic outcome chosen by the apiKey, so the whole Firestore-trigger → `SyncFlight`/`EnableSync` → status state-machine can be exercised in dev by just creating Firestore docs.

## How it works

Providers are dispatched by a system string via two `switch` statements (no shared interface). This follows the exact pattern: new `systemMock` constant + a `case` in `EnableSync` (`internal/activate.go`) and `syncUser` (`internal/import.go`), backed by a new `internal/mock` package.

**apiKey → outcome** (matched case-insensitively; default is success so the happy path just works):

| apiKey contains | Activation | Import | Resulting status |
|---|---|---|---|
| _(default, e.g. `mock`)_ | success | success | activate→success, flight→success |
| `fail-activate` | error | — | user→`failure` |
| `fail-import` | success | generic error | flight→`failure` |
| `fail-auth` | success | `MissingRequiredSubscription` error | flight→`auth_failure`, user→`account_failure` |

(Import-failure keys still activate successfully, because a flight is only imported once the connection is `success`.)

## Scope / safety

No gating — per discussion, `mock` works in any env; you're the only one who'll ever set `type:"mock"`. No new dependencies, no deploy/workflow changes.

## Testing

- `go build` ✅, `go vet` ✅ (only the pre-existing `retry.go` unreachable-code warning).
- New `internal/mock/mock_test.go` covers the apiKey→outcome mapping ✅.
- The two failing `capzlog` tests (`TestImportPilotPIC`, `TestImportInstructor`) were verified to **already fail on `main`** (PIC-name commit) — unrelated to this change; the `mock` package doesn't touch capzlog.

## Try it in dev (after merge + deploy)

1. On a test user: `pilotLogbookSync = { type:"mock", apiKey:"mock", status:"new" }` → `activatePilotLogBookSync` sets status `success` (logs show `[mock] ActivateUser`).
2. Create a flight + a `pilotLogbookSync/{id}` job with `type:"mock"`, `status:"new"` → `syncPilotLogBook` logs `[mock] Import flight…`, job → `success`.
3. Failure branches: use apiKey `mock-fail-import` / `mock-fail-auth` / `mock-fail-activate`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)